### PR TITLE
:alien: Set dtype of empty series

### DIFF
--- a/volue_insight_timeseries/util.py
+++ b/volue_insight_timeseries/util.py
@@ -123,7 +123,7 @@ class TS(object):
         if name is None:
             name = self.fullname
         if self.points is None or len(self.points) == 0:
-            return pd.Series(name=name)
+            return pd.Series(name=name, dtype='float64')
 
         index = []
         values = []


### PR DESCRIPTION
I would like to clean up our logs in spotex a bit and we often get a the warning specified below when we try to read data for a time period where a curve does not contain data. As 'float64' is currently still the default dtype, I believe this proposed change should be safe and not have any effect beyond silencing the future warning.

```diff
- FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning
```
