### PR TITLE
docs: Fixed RTD link on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ the latest Python version.
 ## Documentation
 
 The 
-[documentation](https://wattsight-volue-insight-timeseries.readthedocs-hosted.com/en/latest/ 
+[documentation](https://wattsight-volue-insight-timeseries.readthedocs-hosted.com/en/master/) 
 with various 
-[examples](https://wattsight-volue-insight-timeseries.readthedocs-hosted.com/en/latest/examples.html)
+[examples](https://wattsight-volue-insight-timeseries.readthedocs-hosted.com/en/master/examples.html)
 is hosted on Read the Docs.
 
 ## Installation


### PR DESCRIPTION
The `latest` RTD link is private and based on `development` branch. The `master` is public and based on `master` branch