### PR TITLE
chore: tell dependabot to watch for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+ 


### PR DESCRIPTION
With this, dependabot can suggest updating github-actions to newest version, because actions also come with new versions.