### PR TITLE
fix(deps): Move dependencies used in examples to extras

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,7 +3,7 @@
 Examples
 ========
 
-To run the examples, you need to install ``matplotlib`` and ``plotly``. Using pip, you can install them with the following command:
+To run the examples, you need to install ``matplotlib`` and ``plotly``. Using ``pip``, you can install them with the following command:
 
 .. code-block:: bash
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,6 +3,12 @@
 Examples
 ========
 
+To run the examples, you need to install ``matplotlib`` and ``plotly``. Using pip, you can install them with the following command:
+
+.. code-block:: bash
+
+    pip install matplotlib plotly
+
 
 TIME_SERIES curve examples
 ---------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ requests>=2.18
 sseclient-py>=1.7
 pandas>=1.5.0
 future>=0.16
-matplotlib==3.8.4
-plotly==5.22.0

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,12 @@ setup(
         'pytest-cov >= 2.5',
         'requests-mock >= 1.3',
     ],
+    extras_require={
+        'examples': [
+            'matplotlib',
+            'plotly',
+        ],
+    },
     version=version,
     description='Volue Insight API python library',
     long_description='This library is meant as a simple toolkit for working with data from https://api.volueinsight.com/ (or equivalent services).  Note that access is based on some sort of login credentials, this library is not all that useful unless you have a valid Volue Insight account.',

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,6 @@ setup(
         'pytest-cov >= 2.5',
         'requests-mock >= 1.3',
     ],
-    extras_require={
-        'examples': [
-            'matplotlib',
-            'plotly',
-        ],
-    },
     version=version,
     description='Volue Insight API python library',
     long_description='This library is meant as a simple toolkit for working with data from https://api.volueinsight.com/ (or equivalent services).  Note that access is based on some sort of login credentials, this library is not all that useful unless you have a valid Volue Insight account.',


### PR DESCRIPTION
At some point `matplotlib` and `plotly` was added to `requirements.txt`. These dependencies are causing some issues as they are also hard pinned. Since these dependencies are only used in the examples, I suggest moving them to the `extras_require` section of `setup.py`. If they should also have some version bounds, I'm not sure. I reckon it is ok to have them open, as they are not critical.