### PR TITLE
chore: fix basic smelly code based on default ruff

### DIFF
--- a/examples/Instance_curve_examples/ins_get_multiple_curves.py
+++ b/examples/Instance_curve_examples/ins_get_multiple_curves.py
@@ -42,7 +42,7 @@ if not os.path.isdir(data_dir):
     os.mkdir(data_dir)
 
 # Create a session to Connect to Volue Insight API
-session = volue_insight_timeseries.Session(config_file=config_file)
+session = volue_insight_timeseries.Session(config_file=my_config_file)
 
 # loop through the given curves
 for c, curve_name in enumerate(curve_names):

--- a/examples/Listening_for_changes/renewables_database.py
+++ b/examples/Listening_for_changes/renewables_database.py
@@ -12,7 +12,6 @@ curves and this script actually does something
 
 import volue_insight_timeseries
 import pandas as pd
-import matplotlib.pyplot as plt
 import time
 import os
 

--- a/examples/Timeseries_curve_examples/ts_get_multiple_curves.py
+++ b/examples/Timeseries_curve_examples/ts_get_multiple_curves.py
@@ -45,7 +45,7 @@ if not os.path.isdir(data_dir):
     os.mkdir(data_dir)
 
 # Create a session to Connect to Volue Insight API
-session = volue_insight_timeseries.Session(config_file=config_file)
+session = volue_insight_timeseries.Session(config_file=my_config_file)
 
 # loop through the given curves
 for c, curve_name in enumerate(curve_names):

--- a/examples/general_examples/gen_pv_actuals_vs_forecast.py
+++ b/examples/general_examples/gen_pv_actuals_vs_forecast.py
@@ -7,6 +7,7 @@ The comparison can be performed for any region
 import volue_insight_timeseries
 import pandas as pd
 import matplotlib.pyplot as plt
+import numpy as np
 
 ############################################
 # Insert the path to your config file here!

--- a/examples/general_examples/gen_save_pandas.py
+++ b/examples/general_examples/gen_save_pandas.py
@@ -7,7 +7,6 @@ https://pandas.pydata.org/pandas-docs/stable/io.html
 
 import volue_insight_timeseries
 import pandas as pd
-import matplotlib.pyplot as plt
 import os
 
 ############################################

--- a/examples/intraday_examples/absolute_intraday_price_forecast.py
+++ b/examples/intraday_examples/absolute_intraday_price_forecast.py
@@ -6,7 +6,6 @@ https://wattsight-wapi-python.readthedocs-hosted.com/en/latest/
 """
 
 import volue_insight_timeseries
-import pandas as pd
 import matplotlib.pyplot as plt
 
 ############################################

--- a/examples/intraday_examples/intraday_price_forecast.py
+++ b/examples/intraday_examples/intraday_price_forecast.py
@@ -61,11 +61,11 @@ intraday_price_forecast = intraday_price_forecast_wapi.to_pandas()
 # The fetched data contains our latest price forecast for the intraday market.
 
 # Plot curve using the integrated plot function of pandas.
-latest_intraday_price_forecast.plot(color='blue', marker='o', label='latest')
+intraday_price_forecast.plot(color='blue', marker='o', label='latest')
 
 # The name of the pandas.Series includes the point of time the forecast was made.
 print('Name of the pandas.Series containing the issue_date: {}'.format(
-latest_intraday_price_forecast.name))
+intraday_price_forecast.name))
 
 # Show the figure.
 plt.ylabel('Price/€')

--- a/examples/large_volume_examples/get_long_timeseries.py
+++ b/examples/large_volume_examples/get_long_timeseries.py
@@ -70,10 +70,10 @@ for r in regions:
 
         # Remove empty elements at start/end of time series
         i = 0
-        l = len(frag.points)
-        while i < l and frag.points[i][1] is None:
+        frag_len = len(frag.points)
+        while i < frag_len and frag.points[i][1] is None:
             i += 1
-        j = l
+        j = frag_len
         while j > i and frag.points[j-1][1] is None:
             j -= 1
         frag.points = frag.points[i:j]

--- a/volue_insight_timeseries/__init__.py
+++ b/volue_insight_timeseries/__init__.py
@@ -6,6 +6,15 @@ import os
 from .session import Session
 from . import auth, curves, events, session, util
 
+__all__ = [
+    "Session",
+    "auth",
+    "curves",
+    "events",
+    "session",
+    "util"
+]
+
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'VERSION')) as fv:
     VERSION = __version__ = fv.read().strip()

--- a/volue_insight_timeseries/auth.py
+++ b/volue_insight_timeseries/auth.py
@@ -2,7 +2,6 @@
 # Authentication support
 #
 
-import imp
 import json
 import time
 import threading

--- a/volue_insight_timeseries/events.py
+++ b/volue_insight_timeseries/events.py
@@ -60,7 +60,7 @@ class EventListener:
                         if sse_event.retry is not None:
                             try:
                                 self.retry = int(sse_event.retry)
-                            except:
+                            except ValueError:
                                 pass
                         if self.do_shutdown:
                             break
@@ -107,7 +107,7 @@ class DefaultEvent(object):
         self._raw_event = sse_event
         try:
             self.json_data = json.loads(sse_event.data)
-        except:
+        except json.JSONDecodeError:
             self.json_data = None
 
 


### PR DESCRIPTION
I think out-of-the-box ruff can catch majority of the smelly code - it seems that some examples were also with some errors, which i have fixed now.