### PR TITLE
chore: fix incorrect pandas mapping warning

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,13 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.9', '3.10' , '3.11', '3.12']
-        libraries-versions: [ 'pandas==1.5.2 numpy<2.0.0', 'pandas>=2.2.0']
+        pandas-version: ['1.5.2', '>=2.2.0']
+        numpy-version: ['<2.0', 'latest']
+        exclude:
+          - pandas-version: '1.5.2'
+            numpy-version: 'latest'  # Exclude pandas 1.5.2 with latest numpy
+          - pandas-version: '>=2.2.0'
+            numpy-version: '<2.0'    # Exclude pandas >=2.2.0 with numpy < 2.0
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -32,7 +38,7 @@ jobs:
         run: |
           REQS="-r requirements.txt -r test-requirements.txt"
           pip install --upgrade --upgrade-strategy eager ${REQS}
-          pip install ${{ matrix.libraries-versions }}
+          pip install pandas${{ matrix.pandas-version }} numpy${{ matrix.numpy-version }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.9', '3.10' , '3.11', '3.12']
-        libraries-versions: [ 'pandas==1.5.2', 'pandas>=2.2.0']
+        libraries-versions: [ 'pandas==1.5.2 numpy<2.0.0', 'pandas>=2.2.0']
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,13 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.9', '3.10' , '3.11', '3.12']
-        pandas-version: ['1.5.2', '>=2.2.0']
-        numpy-version: ['<2.0', 'latest']
-        exclude:
-          - pandas-version: '1.5.2'
-            numpy-version: 'latest'
-          - pandas-version: '>=2.2.0'
-            numpy-version: '<2.0'
+        libraries-versions: [ 'pandas==1.5.2 "numpy<2.0"', 'pandas>=2.2.0']
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -38,7 +32,7 @@ jobs:
         run: |
           REQS="-r requirements.txt -r test-requirements.txt"
           pip install --upgrade --upgrade-strategy eager ${REQS}
-          pip install "pandas${{ matrix.pandas-version }}" "numpy${{ matrix.numpy-version }}"
+          pip install ${{ matrix.libraries-versions }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,9 +19,9 @@ jobs:
         numpy-version: ['<2.0', 'latest']
         exclude:
           - pandas-version: '1.5.2'
-            numpy-version: 'latest'  # Exclude pandas 1.5.2 with latest numpy
+            numpy-version: 'latest'
           - pandas-version: '>=2.2.0'
-            numpy-version: '<2.0'    # Exclude pandas >=2.2.0 with numpy < 2.0
+            numpy-version: '<2.0'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -38,7 +38,7 @@ jobs:
         run: |
           REQS="-r requirements.txt -r test-requirements.txt"
           pip install --upgrade --upgrade-strategy eager ${REQS}
-          pip install pandas${{ matrix.pandas-version }} numpy${{ matrix.numpy-version }}
+          pip install "pandas${{ matrix.pandas-version }}" "numpy${{ matrix.numpy-version }}"
 
       - name: Run tests
         run: |

--- a/volue_insight_timeseries/util.py
+++ b/volue_insight_timeseries/util.py
@@ -57,7 +57,6 @@ _PANDAS_FREQ_TABLE = {
     '15T': 'MIN15',
     '5T': 'MIN5',
     'T': 'MIN',
-    'D': 'D',
 }
 for ts_freq, pandas_freq in _TS_FREQ_TABLE.items():
     _PANDAS_FREQ_TABLE[pandas_freq.upper()] = ts_freq

--- a/volue_insight_timeseries/util.py
+++ b/volue_insight_timeseries/util.py
@@ -39,6 +39,7 @@ _TS_FREQ_TABLE = {
     'MIN15': '15min',
     'MIN5': '5min',
     'MIN': 'min',
+    'D': 'D',
 }
 
 # Mapping from various versions of Pandas to TS is built from map above,
@@ -56,6 +57,7 @@ _PANDAS_FREQ_TABLE = {
     '15T': 'MIN15',
     '5T': 'MIN5',
     'T': 'MIN',
+    'D': 'D',
 }
 for ts_freq, pandas_freq in _TS_FREQ_TABLE.items():
     _PANDAS_FREQ_TABLE[pandas_freq.upper()] = ts_freq


### PR DESCRIPTION
Supposedly Frequency.D is not supported, but it is not the case (it works correctly). I added Frequency.D to both maps to ensure that we don't get the warning incorrectly. Here are the logs:
```
[2024-09-11, 14:42:59 UTC] {pod_manager.py:472} INFO - [base] /usr/local/lib/python3.11/site-packages/volue_insight_timeseries/util.py:156: FutureWarning: Frequency is not supported: 'D'
[2024-09-11, 14:42:59 UTC] {pod_manager.py:472} INFO - [base]   frequency = TS._rev_map_freq(pd_series.index.freqstr)
[2024-09-11, 14:42:59 UTC] {pod_manager.py:472} INFO - [base] /usr/local/lib/python3.11/site-packages/volue_insight_timeseries/util.py:156: FutureWarning: Frequency is not supported: 'D'
[2024-09-11, 14:42:59 UTC] {pod_manager.py:490} INFO - [base]   frequency = TS._rev_map_freq(pd_series.index.freqstr)
```

Moreover fixed GHA unittests which were failing due to pandas reqs not having upper bound for numpy thus failing in numpy>=2.0.0 versions 😅 