### PR TITLE
fix: Add del method to EventListener

### DIFF
--- a/volue_insight_timeseries/events.py
+++ b/volue_insight_timeseries/events.py
@@ -87,6 +87,9 @@ class EventListener:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def __del__(self):
+        self.close()
+
 
 class EventError:
     def __init__(self, exception):


### PR DESCRIPTION
Referencing https://github.com/volueinsight/wapi-python/pull/200

This PR adds a del method to the EventListener class to ensure proper cleanup of worker threads and SSE client connections when instances are garbage collected.

**Changes:**
- Added del method that calls the existing close() method
- Ensures resource cleanup even when users don't explicitly call close() or use context managers
- Maintains compatibility with existing usage patterns (context managers and explicit close())

**Benefits:**
- Prevents potential thread leaks when EventListener objects go out of scope
- Provides deterministic resource cleanup through Python's garbage collection

The change is minimal and non-breaking, building on top of the existing close() implementation that's already well-tested