### PR TITLE
fix: Update package name to comply PEP625

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(here, 'volue_insight_timeseries/VERSION')) as fv:
     version = fv.read().strip()
 
 setup(
-    name='volue-insight-timeseries',
+    name='volue_insight_timeseries',
     python_requires='>=3.9, <3.13a0',
     packages=find_packages(),
     install_requires=extract_requirements('requirements.txt'),


### PR DESCRIPTION
- changed py setup project name to comply https://peps.python.org/pep-0625/
